### PR TITLE
feat(backend): implementación del CRUD de categoria

### DIFF
--- a/src/main/java/com/hampcode/api/AdminCategoryController.java
+++ b/src/main/java/com/hampcode/api/AdminCategoryController.java
@@ -1,7 +1,59 @@
 package com.hampcode.api;
 
+import com.hampcode.model.entity.Category;
+import com.hampcode.service.AdminCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.logging.Handler;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/admin/categories")
 public class AdminCategoryController {
-    void hello() {
-        System.out.println("Hello from AdminCategoryController");
+    private final AdminCategoryService adminCategoryService;
+
+    @GetMapping
+    public ResponseEntity<List<Category>> getAllCategories(){
+        List<Category> categories = adminCategoryService.getAll();
+        return new ResponseEntity<List<Category>>(categories,HttpStatus.OK);
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<Page<Category>> paginateCategories(
+            @PageableDefault(size =5, sort ="name")Pageable pageable){
+        Page<Category> categories = adminCategoryService.paginate(pageable);
+        return new ResponseEntity<Page<Category>>(categories,HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Category> getCategoryById(@PathVariable("id") Integer id){
+        Category category = adminCategoryService.findById(id);
+        return new ResponseEntity<Category>(category,HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<Category> createCategory(@RequestBody Category category){
+        Category newCategory = adminCategoryService.create(category);
+        return new ResponseEntity<Category>(newCategory,HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Category> updateCategory(@PathVariable("id") Integer id,
+                                                   @RequestBody Category category){
+        Category updateCategory = adminCategoryService.update(id,category);
+        return new ResponseEntity<Category>(updateCategory,HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Category> deleteCategory(@PathVariable("id") Integer id){
+        adminCategoryService.delete(id);
+        return new ResponseEntity<Category>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/hampcode/repository/CategoryRepository.java
+++ b/src/main/java/com/hampcode/repository/CategoryRepository.java
@@ -1,5 +1,8 @@
 package com.hampcode.repository;
 
-public interface CategoryRepository {
-    void hello();
+import com.hampcode.model.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category,Integer> {
+
 }

--- a/src/main/java/com/hampcode/service/AdminCategoryService.java
+++ b/src/main/java/com/hampcode/service/AdminCategoryService.java
@@ -1,5 +1,16 @@
 package com.hampcode.service;
 
+import com.hampcode.model.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
 public interface AdminCategoryService {
-    void hello();
+    List<Category> getAll();
+    Page<Category> paginate(Pageable pageable);
+    Category findById(Integer id);
+    Category create(Category category);
+    Category update(Integer id, Category updateCategory);
+    void delete(Integer id);
 }

--- a/src/main/java/com/hampcode/service/impl/AdminCategoryServiceImpl.java
+++ b/src/main/java/com/hampcode/service/impl/AdminCategoryServiceImpl.java
@@ -1,7 +1,62 @@
 package com.hampcode.service.impl;
 
-public class AdminCategoryServiceImpl {
-    public void hello() {
-        System.out.println("Hello from AdminCategoryServiceImpl");
+import com.hampcode.model.entity.Category;
+import com.hampcode.repository.CategoryRepository;
+import com.hampcode.service.AdminCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AdminCategoryServiceImpl implements AdminCategoryService {
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Category> getAll() {
+        return categoryRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Category> paginate(Pageable pageable) {
+        return categoryRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Category findById(Integer id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Category not found"));
+    }
+
+    @Transactional
+    @Override
+    public Category create(Category category) {
+        category.setCreatedAt(LocalDateTime.now());
+        return categoryRepository.save(category);
+    }
+
+    @Transactional
+    @Override
+    public Category update(Integer id, Category updateCategory) {
+        Category categoryFromDb = findById(id);
+        categoryFromDb.setName(updateCategory.getName());
+        categoryFromDb.setDescription(updateCategory.getDescription());
+        categoryFromDb.setUpdatedAt(LocalDateTime.now());
+        return categoryRepository.save(categoryFromDb);
+    }
+
+    @Transactional
+    @Override
+    public void delete(Integer id) {
+        Category category = findById(id);
+        categoryRepository.delete(category);
     }
 }


### PR DESCRIPTION
Este pull request añade la implementación completa de las operaciones CRUD (Crear, Leer, Actualizar, Eliminar) para la entidad `Category` . 

### Cambios Realizados

- Se añadió el repositorio `CategoryRepository` con métodos básicos de CRUD.
- Se creó el servicio `AdminCategoryService` y `AdminCategoryServiceImpl` con la lógica de negocio para gestionar categorías.
- Se implementó el controlador `AdminCategoryController` con endpoints REST para las operaciones CRUD.
- Se realizaron las pruebas para verificar la funcionalidad del CRUD mediante Postman.
